### PR TITLE
fix typo of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ export MSAGENT_LOG_LEVEL=DEBUG
 msagent -v
 
 支持的级别（从低到高）：`DEBUG` < `INFO` < `WARNING` < `ERROR` < `CRITICAL`
-
+```
 ### 3) 🔐 配置 LLM
 
 当前 `config` 子命令直接支持的 Provider 是：`openai`、`anthropic`、`gemini`、`google`、`custom`。


### PR DESCRIPTION
<img width="871" height="572" alt="image" src="https://github.com/user-attachments/assets/3c5fcd19-bb14-4d3d-9c25-fb0be0d59e8d" />

这里的显示有问题，经检查，少了一个```结尾符号，添加完毕后是这样的

<img width="812" height="613" alt="image" src="https://github.com/user-attachments/assets/11415bf5-6232-4c19-8813-282e486d4698" />
